### PR TITLE
Add big-iq-cloud-edition lab

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -72,6 +72,12 @@
       <div class="f5-classes">
         {{ class_html }}
       </div>
+      <div class="row">
+            <h2>Other Labs</h2>
+      </div>
+      <div class="f5-classes">
+        <a class="f5-class-item" href="big-iq-cloud-edition/html">F5 BIG-IQ and BIG-IP Cloud Edition</a>
+      </div>
     </div>
 
     </div>


### PR DESCRIPTION
Request to add the link to my lab to Training > Community page (but outside the f5-agility-labs repo).
Therefore, I don't depend on pull request acceptance to update my lab through the year (BIG-IQ training on latest features 6.0, 6.1, 7.0)